### PR TITLE
feat: Adding dependabot-for checking python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "pip"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
As part of this PR:
Added dependabot.yml while will daily check new python packages if released and will raise PR so in future if any dependency gets incompatible, PRs could help to track.