### PR TITLE
Update getProducts to use a Pythonic way

### DIFF
--- a/base/views/product_views.py
+++ b/base/views/product_views.py
@@ -13,9 +13,7 @@ from rest_framework import status
 
 @api_view(['GET'])
 def getProducts(request):
-    query = request.query_params.get('keyword')
-    if query == None:
-        query = ''
+    query = request.query_params.get('keyword') or ''
 
     products = Product.objects.filter(
         name__icontains=query).order_by('-createdAt')


### PR DESCRIPTION
Instead of using:
`
query = request.query_params.get('keyword')
if query == None:
    query = ''
`
which is right by the way, we better use the Pythonic way of doing it:
`
query = request.query_params.get('keyword') or ''
`