### PR TITLE
Solve payment method issue correctly

### DIFF
--- a/frontend/src/screens/PlaceOrderScreen.js
+++ b/frontend/src/screens/PlaceOrderScreen.js
@@ -22,11 +22,6 @@ function PlaceOrderScreen({ history }) {
 
     cart.totalPrice = (Number(cart.itemsPrice) + Number(cart.shippingPrice) + Number(cart.taxPrice)).toFixed(2)
 
-
-    if (!cart.paymentMethod) {
-        history.push('/payment')
-    }
-
     useEffect(() => {
         if (success) {
             history.push(`/order/${order._id}`)

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -69,11 +69,14 @@ const userInfoFromStorage = localStorage.getItem('userInfo') ?
 const shippingAddressFromStorage = localStorage.getItem('shippingAddress') ?
     JSON.parse(localStorage.getItem('shippingAddress')) : {}
 
+const paymentMethodFromStorage = localStorage.getItem('paymentMethod') ?
+    JSON.parse(localStorage.getItem('paymentMethod')) : {}
 
 const initialState = {
     cart: {
         cartItems: cartItemsFromStorage,
         shippingAddress: shippingAddressFromStorage,
+        paymentMethod: paymentMethodFromStorage
     },
     userLogin: { userInfo: userInfoFromStorage },
 }


### PR DESCRIPTION
Instead of redirecting the user when he's refreshing the placeorder page to the payment page again and making him choose the payment method and then continue, as you did in the course, we instead initialize the state with the paymentMethod value from the localStorage this way the user when he refreshes the placeorder page doesn't get redirected to the payment page.