### PR TITLE
reset the review every time we render ProductScreen

### DIFF
--- a/frontend/src/screens/ProductScreen.js
+++ b/frontend/src/screens/ProductScreen.js
@@ -29,10 +29,10 @@ function ProductScreen({ match, history }) {
     } = productReviewCreate
 
     useEffect(() => {
+        dispatch({ type: PRODUCT_CREATE_REVIEW_RESET });
         if (successProductReview) {
             setRating(0)
             setComment('')
-            dispatch({ type: PRODUCT_CREATE_REVIEW_RESET })
         }
 
         dispatch(listProductDetails(match.params.id))


### PR DESCRIPTION
The problem was that when we get an error in a product after trying to create a review, and we go to other product the error stays in the state and renders for every product. So we reset the review state every time the component renders.